### PR TITLE
do not stringify error details

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = exports = (schema, message) => fn => {
     const error = Joi.validate(body, schema).error
 
     if (error) {
-      send(res, 400, message || JSON.stringify(error.details))
+      send(res, 400, message || error.details)
       return
     }
 


### PR DESCRIPTION
error.details is an array, with such a type, micro will auto set the header Content-Type to application/json, which is actually the 
 correct type.